### PR TITLE
Add support for image tags.

### DIFF
--- a/gfms.js
+++ b/gfms.js
@@ -172,6 +172,10 @@ app.get('*', function(req, res, next) {
 
     }
     else if(is_image(dir)) {
+        //if the image is being loaded in an img tag just send the file
+        if(req.headers.accept.indexOf('text/html') === -1) {
+            return res.sendFile(dir);
+        }
 
         if(!watched[dir]) {
             fs.watchFile(dir, { interval: 500 }, function(curr, prev) {


### PR DESCRIPTION
If an image is linked via src tag it shouId send the file without wrapping it in html

Currently if you use markdown to link to an image the server tries to serve it up wrapped in html which is nice when viewing an image directly, but breaks any image tags. This fix uses the "accepts" header tag to send an image if the browser says it doesn't support html (which will be the case for all <img src="image"> references)

