### PR TITLE
Bug/cant invoke without new

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "gfms",
-    "version": "0.0.12",
+    "version": "0.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,11 +75,6 @@
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
-        "async-limiter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
-        },
         "async-mini": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/async-mini/-/async-mini-0.2.0.tgz",
@@ -744,6 +739,11 @@
                 "wordwrap": "~0.0.2"
             }
         },
+        "options": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+            "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+        },
         "parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1090,6 +1090,11 @@
             "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
             "optional": true
         },
+        "ultron": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+            "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+        },
         "underscore": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
@@ -1180,11 +1185,12 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
-            "integrity": "sha512-ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+            "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
             "requires": {
-                "async-limiter": "^1.0.0"
+                "options": ">=0.0.5",
+                "ultron": "1.0.x"
             }
         },
         "ws-rpc": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "render",
         "gfm"
     ],
-    "version": "0.0.12",
+    "version": "0.1.0",
     "homepage": "http://github.com/ypocat/gfms",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "node": "*"
     },
     "dependencies": {
+        "async-mini": "*",
         "express": "*",
         "marked": "*",
         "highlight.js": "*",
@@ -36,12 +37,11 @@
         "nib": "*",
         "optimist": "*",
         "request": "*",
-        "ws": "*",
-        "ws-rpc": "*",
         "stylus": "*",
         "underscore": "*",
         "utilz": "*",
-        "async-mini": "*"
+        "ws": "^1.1.5",
+        "ws-rpc": "0.0.8"
     },
     "devDependencies": {},
     "licenses": [


### PR DESCRIPTION
This PR fixes #38 plus...

- add .npmrc to prevent problems with company registries (often set in `~/.npmrc`)
- add lock file with may prevent further version problems 
- upgrade minor version (due to new feature in #39)